### PR TITLE
Fixed length padding for short messages

### DIFF
--- a/src/libomemo_crypto.c
+++ b/src/libomemo_crypto.c
@@ -5,18 +5,14 @@
 
 #include "libomemo.h"
 
+#define MINIMUM_PADDED_LENGTH 256
+#define PADDING_CHARACTER     ' '
 
-void omemo_default_crypto_init(void) {
-  (void) gcry_check_version((void *) 0);
-  gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
-  gcry_control (GCRYCTL_INIT_SECMEM, 16384, 0);
-  gcry_control (GCRYCTL_RESUME_SECMEM_WARN);
-  gcry_control(GCRYCTL_USE_SECURE_RNDPOOL);
-  gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
+/* text below this length will be padded to a number of fixed lengths */
+#define SHORT_MESSAGE_LENGTH  4096
 
-}
-
-int omemo_default_crypto_random_bytes(uint8_t ** buf_pp, size_t buf_len, void * user_data_p) {
+int omemo_default_crypto_random_bytes(uint8_t ** buf_pp, size_t buf_len,
+                                      void * user_data_p) {
   (void) user_data_p;
 
   if (!buf_pp) {
@@ -33,6 +29,125 @@ int omemo_default_crypto_random_bytes(uint8_t ** buf_pp, size_t buf_len, void * 
   *buf_pp = buf_p;
 
   return 0;
+}
+
+/* returns a random offset value for the beginning of a padded message */
+int omemo_padding_random_offset(unsigned int max_offset,
+                                unsigned int * offset) {
+  uint8_t * buf = (void *) 0;
+  if (omemo_default_crypto_random_bytes(&buf, sizeof(unsigned int),
+                                        (void *) 0) != 0)
+    return OMEMO_ERR_NOMEM;
+
+  *offset =
+    (unsigned int)((buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3]) %
+    max_offset;
+
+  free(buf);
+  return 0;
+}
+
+/* returns the padded length for the given string length */
+size_t omemo_padding_length(size_t plaintext_len, size_t paddedtext_max_len) {
+  size_t pad = MINIMUM_PADDED_LENGTH;
+
+  while (plaintext_len > pad)
+    pad *= 2;
+
+  if (pad > paddedtext_max_len)
+    pad = paddedtext_max_len;
+
+  return pad;
+}
+
+/* Pad the text to a minimum of 255 characters, by adding random amount of
+   spaces before and after plaintext. */
+int omemo_padding_add(uint8_t * plaintext_p, size_t plaintext_len,
+                      uint8_t * paddedtext_p, size_t paddedtext_max_len,
+                      size_t * paddedtext_len) {
+  unsigned int offset;
+  size_t pad;
+
+  /* empty string */
+  if (plaintext_len == 0)
+    return 1;
+
+  /* maximum padded text length is too short */
+  if (paddedtext_max_len < plaintext_len)
+    return 2;
+
+  /* get the padding length */
+  pad = omemo_padding_length(plaintext_len, paddedtext_max_len);
+
+  /* clear the padded text */
+  memset((void*)paddedtext_p, PADDING_CHARACTER, pad*sizeof(uint8_t));
+
+  /* get a random offset for the beginning of the plaintext
+     within the padded text */
+  if (omemo_padding_random_offset(pad - plaintext_len - 1,
+                                  &offset) != 0)
+    return 3;
+
+  /* ensure that any string terminator isn't copied */
+  if (plaintext_p[plaintext_len-1] == 0)
+    plaintext_len--;
+
+  /* copy the plaintext into the padded text at the given offset */
+  memcpy((void*)&paddedtext_p[offset], (void*)plaintext_p, plaintext_len);
+
+  /* add a string terminator */
+  paddedtext_p[pad-1] = 0;
+
+  /* return the padded text length */
+  *paddedtext_len = pad;
+
+  return 0;
+}
+
+void omemo_padding_remove(uint8_t * paddedtext_p, size_t paddedtext_len,
+                          uint8_t * plaintext_p, size_t * plaintext_len) {
+  unsigned int start_offset=0, end_offset, i;
+
+  /* empty string */
+  if (paddedtext_len == 0) {
+    plaintext_p[0] = 0;
+    *plaintext_len = 0;
+    return;
+  }
+
+  /* find the start of the text */
+  while (start_offset < paddedtext_len) {
+    if (paddedtext_p[start_offset] != PADDING_CHARACTER)
+      break;
+    start_offset++;
+  }
+
+  /* find the end of the text */
+  end_offset=(unsigned int)paddedtext_len-1;
+  while (end_offset > 0) {
+      if ((paddedtext_p[end_offset] != PADDING_CHARACTER) &&
+        (paddedtext_p[end_offset] != 0))
+      break;
+    end_offset--;
+  }
+
+  /* get the unpadded text */
+  for (i = start_offset; i <= end_offset; i++)
+    plaintext_p[i-start_offset] = paddedtext_p[i];
+  plaintext_p[i - start_offset] = 0;
+
+  /* return the unpadded length */
+  *plaintext_len = (end_offset - start_offset) + 1;
+}
+
+void omemo_default_crypto_init(void) {
+  (void) gcry_check_version((void *) 0);
+  gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
+  gcry_control (GCRYCTL_INIT_SECMEM, 16384, 0);
+  gcry_control (GCRYCTL_RESUME_SECMEM_WARN);
+  gcry_control(GCRYCTL_USE_SECURE_RNDPOOL);
+  gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
+
 }
 
 int omemo_default_crypto_aes_gcm_encrypt( const uint8_t * plaintext_p, size_t plaintext_len,
@@ -54,6 +169,25 @@ int omemo_default_crypto_aes_gcm_encrypt( const uint8_t * plaintext_p, size_t pl
   gcry_cipher_hd_t cipher_hd;
   uint8_t * out_p = (void *) 0;
   uint8_t * tag_p = (void *) 0;
+
+  char * paddedtext_p = (void *) 0;
+  size_t paddedtext_len = 0;
+
+  /* for short messages pad to a few fixed lengths */
+  if (plaintext_len < SHORT_MESSAGE_LENGTH) {
+    paddedtext_p =
+      (char *)malloc(sizeof(char)*omemo_padding_length(plaintext_len,
+                                                       SHORT_MESSAGE_LENGTH));
+    if (!paddedtext_p)
+      goto cleanup;
+    if (omemo_padding_add((uint8_t *) plaintext_p, plaintext_len,
+                          (uint8_t *) paddedtext_p, SHORT_MESSAGE_LENGTH,
+                          &paddedtext_len) != 0) {
+      goto cleanup;
+    }
+    plaintext_p = (uint8_t *)paddedtext_p;
+    plaintext_len = paddedtext_len;
+  }
 
   switch(key_len) {
     case 16:
@@ -117,6 +251,8 @@ int omemo_default_crypto_aes_gcm_encrypt( const uint8_t * plaintext_p, size_t pl
   *tag_pp = tag_p;
 
 cleanup:
+  if (paddedtext_p)
+      free(paddedtext_p);
   if (ret_val) {
     free(out_p);
     free(tag_p);
@@ -143,6 +279,8 @@ int omemo_default_crypto_aes_gcm_decrypt( const uint8_t * ciphertext_p, size_t c
   int algo = 0;
   gcry_cipher_hd_t cipher_hd;
   uint8_t * out_p = (void *) 0;
+  uint8_t * unpaddedtext_p = (void *) 0;
+  size_t unpaddedtext_len = 0;
 
   switch(key_len) {
     case 16:
@@ -195,13 +333,22 @@ int omemo_default_crypto_aes_gcm_decrypt( const uint8_t * ciphertext_p, size_t c
     goto cleanup;
   }
 
-  *plaintext_pp = out_p;
-  *plaintext_len_p = ciphertext_len;
+  unpaddedtext_p =
+    (uint8_t *)malloc(sizeof(uint8_t *)*ciphertext_len);
+  if (!unpaddedtext_p) {
+    ret_val = OMEMO_ERR_NOMEM;
+    goto cleanup;
+  }
+  omemo_padding_remove(out_p, ciphertext_len,
+                       unpaddedtext_p, &unpaddedtext_len);
+
+
+  *plaintext_pp = unpaddedtext_p;
+  *plaintext_len_p = unpaddedtext_len+1;
 
 cleanup:
-  if (ret_val) {
+  if (ret_val || (unpaddedtext_len > 0))
     free(out_p);
-  }
 
   gcry_cipher_close(cipher_hd);
 

--- a/src/libomemo_crypto.h
+++ b/src/libomemo_crypto.h
@@ -26,3 +26,15 @@ int omemo_default_crypto_aes_gcm_decrypt( const uint8_t * ciphertext_p, size_t c
                                           uint8_t ** plaintext_pp, size_t * plaintext_len_p);
 
 void omemo_default_crypto_teardown(void);
+
+int omemo_padding_random_offset(unsigned int max_offset,
+                                unsigned int * offset);
+
+size_t omemo_padding_length(size_t plaintext_len, size_t paddedtext_max_len);
+
+int omemo_padding_add(uint8_t * plaintext_p, size_t plaintext_len,
+                      uint8_t * paddedtext_p, size_t paddedtext_max_len,
+                      size_t * paddedtext_len);
+
+void omemo_padding_remove(uint8_t * paddedtext_p, size_t paddedtext_len,
+                          uint8_t * plaintext_p, size_t * plaintext_len);

--- a/test/test_crypto.c
+++ b/test/test_crypto.c
@@ -24,26 +24,27 @@ int openssl_teardown(void ** state) {
 void test_padding_offset(void ** state) {
   (void) state;
 
-  unsigned int bucket[32];
+  unsigned int bucket[32/PADDING_CHARACTER_BYTES];
   unsigned int offset, filled=0;
 
-  memset((void*)&bucket[0],'\0',sizeof(unsigned int)*32);
+  memset((void*)&bucket[0],'\0',
+         sizeof(unsigned int)*32/PADDING_CHARACTER_BYTES);
 
   /* check that buckets are empty */
-  for (unsigned int i = 0; i < 32; i++)
+  for (unsigned int i = 0; i < 32/PADDING_CHARACTER_BYTES; i++)
     assert_int_equal(bucket[i], 0);
 
   /* record some random offset values */
   for (unsigned int i = 0; i < 10000; i++)
     if (omemo_padding_random_offset(32, &offset) == 0) {
-      assert_in_range(offset, 0, 32);
+      assert_in_range(offset, 0, 32/PADDING_CHARACTER_BYTES);
       bucket[offset]++;
     }
 
   /* check the range of offsets */
-  for (unsigned int i = 0; i < 32; i++)
+  for (unsigned int i = 0; i < 32/PADDING_CHARACTER_BYTES; i++)
     if (bucket[i] > 0) filled++;
-  assert_true(filled >= 30);
+  assert_true(filled >= (32/PADDING_CHARACTER_BYTES)-2);
 }
 
 
@@ -53,12 +54,12 @@ void test_padding_length(void ** state) {
   size_t paddings[] = {
     0, MINIMUM_PADDED_LENGTH,
     31, MINIMUM_PADDED_LENGTH,
-    256, MINIMUM_PADDED_LENGTH,
+    256, MINIMUM_PADDED_LENGTH*1,
     257, MINIMUM_PADDED_LENGTH*2,
-    512, MINIMUM_PADDED_LENGTH*2,
-    513, MINIMUM_PADDED_LENGTH*4,
-    1024, MINIMUM_PADDED_LENGTH*4,
-    1025, MINIMUM_PADDED_LENGTH*8,
+    510, MINIMUM_PADDED_LENGTH*2,
+    770, MINIMUM_PADDED_LENGTH*4,
+    1500, MINIMUM_PADDED_LENGTH*8,
+    1600, MINIMUM_PADDED_LENGTH*8,
     0, 0
   };
 

--- a/test/test_crypto.c
+++ b/test/test_crypto.c
@@ -21,6 +21,106 @@ int openssl_teardown(void ** state) {
   return 0;
 }
 
+void test_padding_offset(void ** state) {
+  (void) state;
+
+  unsigned int bucket[32];
+  unsigned int offset, filled=0;
+
+  memset((void*)&bucket[0],'\0',sizeof(unsigned int)*32);
+
+  /* check that buckets are empty */
+  for (unsigned int i = 0; i < 32; i++)
+    assert_int_equal(bucket[i], 0);
+
+  /* record some random offset values */
+  for (unsigned int i = 0; i < 10000; i++)
+    if (omemo_padding_random_offset(32, &offset) == 0) {
+      assert_in_range(offset, 0, 32);
+      bucket[offset]++;
+    }
+
+  /* check the range of offsets */
+  for (unsigned int i = 0; i < 32; i++)
+    if (bucket[i] > 0) filled++;
+  assert_true(filled >= 30);
+}
+
+
+void test_padding_length(void ** state) {
+  (void) state;
+
+  size_t paddings[] = {
+    0, MINIMUM_PADDED_LENGTH,
+    31, MINIMUM_PADDED_LENGTH,
+    256, MINIMUM_PADDED_LENGTH,
+    257, MINIMUM_PADDED_LENGTH*2,
+    512, MINIMUM_PADDED_LENGTH*2,
+    513, MINIMUM_PADDED_LENGTH*4,
+    1024, MINIMUM_PADDED_LENGTH*4,
+    1025, MINIMUM_PADDED_LENGTH*8,
+    0, 0
+  };
+
+  unsigned int i = 0;
+  while (paddings[i+1] != 0) {
+    assert_int_equal((int)omemo_padding_length(paddings[i], 2048),paddings[i+1]);
+    i += 2;
+  }
+}
+
+void test_padding_add(void ** state) {
+  (void) state;
+
+  char paddedtext[1024];
+  char plaintext[1024];
+  char * emptystring="";
+  size_t paddedtext_len = 0;
+
+  sprintf(plaintext,"%s","This is a test");
+
+  assert_int_equal(strlen(plaintext), 14);
+  assert_int_equal(omemo_padding_add((uint8_t *)plaintext, strlen(plaintext),
+                                     (uint8_t *)paddedtext, 1024,
+                                     &paddedtext_len), 0);
+  assert_int_equal(paddedtext_len, MINIMUM_PADDED_LENGTH);
+  assert_int_equal(omemo_padding_add((uint8_t *)emptystring, strlen(emptystring),
+                                     (uint8_t *)paddedtext, 1024,
+                                     &paddedtext_len), 1);
+
+  /* make a longer plaintext string */
+  memset((void*)plaintext,'a',270);
+  plaintext[270] = 0;
+  assert_int_equal(strlen(plaintext), 270);
+
+  /* check that the padding length increases */
+  assert_int_equal(omemo_padding_add((uint8_t *)plaintext, strlen(plaintext),
+                                     (uint8_t *)paddedtext, 1024,
+                                     &paddedtext_len), 0);
+  assert_int_equal(paddedtext_len, MINIMUM_PADDED_LENGTH*2);
+}
+
+void test_padding_remove(void ** state) {
+  (void) state;
+
+  char paddedtext[1024];
+  char unpaddedtext[1024];
+  char * plaintext="This is a test";
+  size_t paddedtext_len = 0;
+  size_t unpaddedtext_len;
+
+  assert_int_equal(omemo_padding_add((uint8_t *)plaintext, strlen(plaintext),
+                                     (uint8_t *)paddedtext, 1024,
+                                     &paddedtext_len), 0);
+  assert_int_equal(paddedtext_len, MINIMUM_PADDED_LENGTH);
+
+  omemo_padding_remove((uint8_t *)paddedtext, paddedtext_len,
+                       (uint8_t *)unpaddedtext, &unpaddedtext_len);
+  assert_int_equal(unpaddedtext_len, strlen(plaintext));
+  assert_int_equal(strlen(plaintext), strlen(unpaddedtext));
+  assert_int_equal(strcmp(plaintext, unpaddedtext), 0);
+}
+
 void test_random_bytes(void ** state) {
   (void) state;
 
@@ -93,6 +193,10 @@ void test_aes_gcm_encrypt_decrypt(void ** state) {
 int main(void) {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_random_bytes),
+      cmocka_unit_test(test_padding_length),
+      cmocka_unit_test(test_padding_add),
+      cmocka_unit_test(test_padding_remove),
+      cmocka_unit_test(test_padding_offset),
       cmocka_unit_test(test_aes_gcm_encrypt_decrypt)
   };
 


### PR DESCRIPTION
This pads short messages to a few fixed lengths, which makes it difficult for an adversary to infer anything about content or origin from an analysis of cyphertext lengths. The same system is used by https://github.com/omemo/python-omemo