### PR TITLE
 More flexible build for Lurch4Adium

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,21 @@
 CC ?= gcc
 AR ?= ar
 LIBTOOL ?= libtool
-PKG_CONFIG ?= pkg-config
-LIBGCRYPT_CONFIG ?= libgcrypt-config
 MKDIR = mkdir
 MKDIR_P = mkdir -p
 
+PKG_CONFIG ?= pkg-config
+GLIB_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags glib-2.0)
+GLIB_LDFLAGS ?= $(shell $(PKG_CONFIG) --libs glib-2.0)
+
+SQLITE3_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags sqlite3)
+SQLITE3_LDFLAGS ?= $(shell $(PKG_CONFIG) --libs sqlite3)
+
+MXML_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags mxml)
+MXML_LDFLAGS ?= $(shell $(PKG_CONFIG) --libs mxml)
+
+LIBGCRYPT_CONFIG ?= libgcrypt-config
+LIBGCRYPT_LDFLAGS ?= $(shell $(LIBGCRYPT_CONFIG) --libs)
 
 SDIR = src
 BDIR = build
@@ -18,10 +28,15 @@ LDIR = lib
 # -fno-builtin-memset is enough to make gcc not optimize it away
 FILES =
 
-PKGCFG_C=$(shell $(PKG_CONFIG) --cflags glib-2.0 sqlite3 mxml) \
-		 $(shell $(LIBGCRYPT_CONFIG) --cflags)
-PKGCFG_L=$(shell $(PKG_CONFIG) --libs glib-2.0 sqlite3 mxml) \
-		 $(shell $(LIBGCRYPT_CONFIG) --libs)
+PKGCFG_C=$(GLIB_CFLAGS) \
+	 $(MXML_CFLAGS) \
+	 $(SQLITE3_CFLAGS) \
+	 $(LIBGCRYPT_CFLAGS)
+
+PKGCFG_L=$(GLIB_LDFLAGS) \
+	 $(MXML_LDFLAGS) \
+	 $(SQLITE3_LDFLAGS) \
+	 $(LIBGCRYPT_LDFLAGS)
 
 CFLAGS += -std=c11 -Wall -Wextra -Wpedantic -Wstrict-overflow \
 		-fno-strict-aliasing -funsigned-char \

--- a/src/libomemo_crypto.c
+++ b/src/libomemo_crypto.c
@@ -51,7 +51,7 @@ int omemo_default_crypto_aes_gcm_encrypt( const uint8_t * plaintext_p, size_t pl
   int ret_val = 0;
 
   int algo = 0;
-  gcry_cipher_hd_t cipher_hd;
+  gcry_cipher_hd_t cipher_hd = NULL;
   uint8_t * out_p = (void *) 0;
   uint8_t * tag_p = (void *) 0;
 
@@ -141,7 +141,7 @@ int omemo_default_crypto_aes_gcm_decrypt( const uint8_t * ciphertext_p, size_t c
   int ret_val = 0;
 
   int algo = 0;
-  gcry_cipher_hd_t cipher_hd;
+  gcry_cipher_hd_t cipher_hd = NULL;
   uint8_t * out_p = (void *) 0;
 
   switch(key_len) {


### PR DESCRIPTION
Make the build more flexible by allowing to override the Makefile variables.

This was needed to support making an Adium plugin in shtrom/Lurch4Adium.

Also fix another few things.