### PR TITLE
use DEFAULT_SOURCE instead of BSD_SOURCE

### DIFF
--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ PKGCFG_L=$(shell $(PKG_CONFIG) --libs glib-2.0 sqlite3 mxml) \
 CFLAGS += -std=c11 -Wall -Wextra -Wpedantic -Wstrict-overflow \
 		-fno-strict-aliasing -funsigned-char \
 		-fno-builtin-memset $(PKGCFG_C)
-CPPFLAGS += -D_XOPEN_SOURCE=700 -D_BSD_SOURCE
+CPPFLAGS += -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE
 CFLAGS_CONVERSATIONS=$(CFLAGS) -DOMEMO_XMLNS='"eu.siacs.conversations.axolotl"' -DOMEMO_NS_SEPARATOR='"."' -DOMEMO_NS_NOVERSION
 COVFLAGS = --coverage -O0 -g $(CFLAGS)
 LDFLAGS += -pthread -ldl -lm $(PKGCFG_L)


### PR DESCRIPTION
BSD_SOURCE is deprecated and its use triggers the following warning (since glibc 2.20 AFAIK):
```
/usr/include/features.h:180:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^~~~~~~
```

This shouldn't make any problems as it's been a long time.