### PR TITLE
12-byte IVs (#24)

### DIFF
--- a/src/libomemo.h
+++ b/src/libomemo.h
@@ -78,7 +78,7 @@ typedef struct omemo_crypto_provider {
 } omemo_crypto_provider;
 
 #define OMEMO_AES_128_KEY_LENGTH 16
-#define OMEMO_AES_GCM_IV_LENGTH  16
+#define OMEMO_AES_GCM_IV_LENGTH  12
 #define OMEMO_AES_GCM_TAG_LENGTH 16
 
 #define OMEMO_LOG_OFF    -1


### PR DESCRIPTION
The XEP-0384 0.3.0 does not specify the "IV" value and the 0.3.1 version has been missing before the 0.4.0 version.
All OMEMO 0.3.0 clients must send with 12-byte instead 16-byte IV.

This PR solves this problem, linked to #24.