### PR TITLE
Built libomemo as a dynamically linked library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ LIBTOOL ?= libtool
 MKDIR = mkdir
 MKDIR_P = mkdir -p
 
+ARCH = $(shell gcc -print-multiarch)
+VER_MAJ = 0
+VERSION = 0.6.2
+
 PKG_CONFIG ?= pkg-config
 GLIB_CFLAGS ?= $(shell $(PKG_CONFIG) --cflags glib-2.0)
 GLIB_LDFLAGS ?= $(shell $(PKG_CONFIG) --libs glib-2.0)
@@ -47,7 +51,7 @@ COVFLAGS = --coverage -O0 -g $(CFLAGS)
 LDFLAGS += -pthread -ldl -lm $(PKGCFG_L)
 TESTFLAGS = -lcmocka $(LDFLAGS)
 
-all: $(BDIR)/libomemo-conversations.a
+all: $(BDIR)/libomemo-conversations.a shared
 
 $(BDIR):
 	$(MKDIR_P) $@
@@ -57,7 +61,7 @@ libomemo: $(SDIR)/libomemo.c libomemo_crypto libomemo_storage $(BDIR)
 	$(LIBTOOL) --mode=link $(CC) -o $(BDIR)/$@.la $(BDIR)/$@.lo $(BDIR)/$@_crypto.lo $(BDIR)/$@_storage.lo
 
 libomemo-conversations: $(SDIR)/libomemo.c libomemo_crypto libomemo_storage $(BDIR)
-	$(LIBTOOL) --mode=compile $(CC) -c $(SDIR)/libomemo.c $(CFLAGS_CONVERSATIONS) -o $(BDIR)/libomemo.lo
+	$(LIBTOOL) --mode=compile $(CC) -c $(SDIR)/libomemo.c $(CFLAGS_CONVERSATIONS) -o $(BDIR)/libomemo.lo $(CPPFLAGS)
 	$(LIBTOOL) --mode=link $(CC) -o $(BDIR)/libomemo.la $(BDIR)/libomemo.lo $(BDIR)/libomemo_crypto.lo $(BDIR)/libomemo_storage.lo
 
 libomemo_crypto: $(SDIR)/libomemo_crypto.c build
@@ -70,7 +74,7 @@ $(BDIR)/libomemo.o: $(BDIR) $(SDIR)/libomemo.c $(SDIR)/libomemo.h
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(SDIR)/libomemo.c -o $@
 
 $(BDIR)/libomemo-conversations.o: $(SDIR)/libomemo.c $(BDIR)
-	$(CC) -c $(SDIR)/libomemo.c $(CFLAGS_CONVERSATIONS) -fPIC -o $@
+	$(CC) -c $(SDIR)/libomemo.c $(CFLAGS_CONVERSATIONS) $(CPPFLAGS) -fPIC -o $@
 
 $(BDIR)/libomemo_crypto.o: $(SDIR)/libomemo_crypto.c $(BDIR)
 	$(CC) -c $(SDIR)/libomemo_crypto.c $(CFLAGS) $(CPPFLAGS) -fPIC -o $@
@@ -80,6 +84,35 @@ $(BDIR)/libomemo_storage.o: $(SDIR)/libomemo_storage.c $(BDIR)
 
 $(BDIR)/libomemo-conversations.a: $(BDIR)/libomemo-conversations.o $(BDIR)/libomemo_crypto.o $(BDIR)/libomemo_storage.o
 	$(AR) rcs $@ $^
+
+$(BDIR)/libomemo.so: $(BDIR)
+	$(CC) -shared $(SDIR)/libomemo.c -Wl,-soname,libomemo.so.$(VER_MAJ) \
+		$(SDIR)/libomemo_crypto.c $(SDIR)/libomemo_storage.c \
+		$(LDFLAGS) $(CPPFLAGS) -fPIC -o $@ $(CFLAGS_CONVERSATIONS)
+
+$(BDIR)/libomemo.pc: $(BDIR)
+	echo 'prefix='$(PREFIX) > $@
+	echo 'exec_prefix=$${prefix}' >> $@
+	echo 'libdir=$${prefix}/lib/$(ARCH)' >> $@
+	echo 'includedir=$${prefix}/include' >> $@
+	echo 'Name: libomemo' >> $@
+	echo 'Version: ${VERSION}' >> $@
+	echo 'Description: OMEMO library for C' >> $@
+	echo 'Requires.private: glib-2.0' >> $@
+	echo 'Cflags: -I$${includedir}/libomemo' >> $@
+	echo 'Libs: -L$${libdir} -lomemo' >> $@
+
+shared: $(BDIR)/libomemo.so $(BDIR)/libomemo.pc
+
+install: $(BDIR)
+	install -d $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/pkgconfig/
+	install -m 644 $(BDIR)/libomemo-conversations.a  $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libomemo.a
+	install -m 644 $(BDIR)/libomemo.so $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libomemo.so.$(VERSION)
+	install -m 644 $(BDIR)/libomemo.pc $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/pkgconfig/
+	install -d $(DESTDIR)/$(PREFIX)/include/libomemo/
+	install -m 644 $(SDIR)/libomemo_crypto.h $(DESTDIR)/$(PREFIX)/include/libomemo/
+	install -m 644 $(SDIR)/libomemo_storage.h $(DESTDIR)/$(PREFIX)/include/libomemo/
+	install -m 644 $(SDIR)/libomemo.h $(DESTDIR)/$(PREFIX)/include/libomemo/
 
 .PHONY = test_libomemo.o
 test_libomemo: $(TDIR)/test_libomemo.c $(SDIR)/libomemo.c


### PR DESCRIPTION
Hi,

as a part of the DebianOnMobile team I have packaged libomemo [1] (the goal ultimatelly is having lurch in Debian).
The library has been accepted into the unstable branch of Debian.

I changed the Makefile to
- built a dynamically linked library under the target `shared`
- add a pkg-config file similar to how it is done in [2] for axc
- add a `install` target
- add `CPPFLAGS` to compilation which is used in debian for hardening

[1] https://salsa.debian.org/DebianOnMobile-team/libomemo
[2] https://github.com/gkdr/axc/pull/17

Cheers

PS: Would you be interested in carrying the `debian/` folder upstream? If so, I can prepare another pull request