### PR TITLE
Add missing symlinks libomemo.so.$(VER_MAJ) and libomemo.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,8 @@ install: $(BDIR)
 	install -d $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/pkgconfig/
 	install -m 644 $(BDIR)/libomemo-conversations.a  $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libomemo.a
 	install -m 644 $(BDIR)/libomemo.so $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libomemo.so.$(VERSION)
+	ln -s libomemo.so.$(VERSION) $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libomemo.so.$(VER_MAJ)
+	ln -s libomemo.so.$(VERSION) $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/libomemo.so
 	install -m 644 $(BDIR)/libomemo.pc $(DESTDIR)/$(PREFIX)/lib/$(ARCH)/pkgconfig/
 	install -d $(DESTDIR)/$(PREFIX)/include/libomemo/
 	install -m 644 $(SDIR)/libomemo_crypto.h $(DESTDIR)/$(PREFIX)/include/libomemo/


### PR DESCRIPTION
Hi!

I use this patch in Gentoo packaging of libomemo. My interest is to get this patch (or some form of this patch) applied upstream so that (1) others can get the patch out of the box and (2) my own patch count downstream in Gentoo goes back to zero, e.g. to reduce the risk of merge conflicts with the next upstream release…

What do you think about the patch?

Best


Sebastian

PS: This pull request has a sibling at https://github.com/gkdr/axc/pull/24