### PR TITLE
Makefile: Fix crosscompilation installing to wrong directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Added missing symlinks for the `.so` files. ([#34](https://github.com/gkdr/libomemo/pull/34)) (thanks, [@hartwork](https://github.com/hartwork)!)
+- Fix crossbuild using wrong multiarch triplet. ([#36](https://github.com/gkdr/libomemo/pull/36)) (thanks, [@fortysixandtwo](https://github.com/fortysixandtwo)!)
 
 ## [0.7.1] - 2021-01-31
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LIBTOOL ?= libtool
 MKDIR = mkdir
 MKDIR_P = mkdir -p
 
-ARCH = $(shell gcc -print-multiarch)
+ARCH = $(shell $(CC) -print-multiarch)
 VER_MAJ = 0
 VERSION = 0.7.1
 


### PR DESCRIPTION
By using $(CC) instead of hardcoding gcc we make sure to get the
correct triplet that is being used for the installation directory.

Credits go to Helmut Grohne for providing a fix, see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003476