### PR TITLE
Cover Linux build by GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the GPL v2 or later
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the GPL v2 or later
+
+name: Build for Linux
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 2 * * 5'  # Every Friday at 2am
+
+jobs:
+  checks:
+    name: Build for Linux
+    runs-on: ubuntu-20.04
+    steps:
+
+    - uses: actions/checkout@v2.4.0
+
+    - name: Install build dependencies
+      run: |-
+        set -x
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends -V \
+            gcovr \
+            libcmocka-dev \
+            libgcrypt20-dev \
+            libglib2.0-dev \
+            libmxml-dev \
+            libsqlite3-dev
+
+    - name: Build
+      run: |-
+        set -x
+        make -j $(nproc) all
+
+    - name: Test
+      run: |-
+        make coverage  # includes tests
+
+    - name: Install
+      run: |-
+        set -x -o pipefail
+        make DESTDIR="${PWD}"/ROOT install
+        find ROOT/ -not -type d | sort | xargs ls -l
+
+    - name: Store coverage HTML report
+      uses: actions/upload-artifact@v2.3.1
+      with:
+        name: coverage
+        path: coverage/
+        if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added missing symlinks for the `.so` files. ([#34](https://github.com/gkdr/libomemo/pull/34)) (thanks, [@hartwork](https://github.com/hartwork)!)
 
+### Infrastructure
+- Cover Linux build by GitHub Actions CI ([#37](https://github.com/gkdr/libomemo/pull/37)) (thanks, [@hartwork](https://github.com/hartwork)!)
+
 ## [0.7.1] - 2021-01-31
 ### Fixed
 - Test file cleanup now won't randomly break parallel builds. ([#31](https://github.com/gkdr/libomemo/pull/31)) (thanks, [@fortysixandtwo](https://github.com/fortysixandtwo)!)


### PR DESCRIPTION
Same as https://github.com/gkdr/axc/pull/31 for axc except:
- no build system fixes needed
- no no-threads variant
- no job matrix (due to no Git submoduels)
- dependency `libmxml-dev` more

So 90% the same, a bit simpler in nature.

Example run log can be seen at https://github.com/hartwork/libomemo/runs/4887954398?check_suite_focus=true .
